### PR TITLE
lib: use static trait methods instead of TLS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! struct PamTime;
 //!
 //! impl PamServiceModule for PamTime {
-//!     fn authenticate(self: &Self, pamh: Pam, _: PamFlag, args: Vec<String>) -> PamError {
+//!     fn authenticate(pamh: Pam, _: PamFlag, args: Vec<String>) -> PamError {
 //!         let hour = time::now().tm_hour;
 //!         if hour != 4 {
 //!             // Only allow authentication when it's 4 AM
@@ -23,7 +23,7 @@
 //!     }
 //! }
 //!
-//! pamsm_init!(Box::new(PamTime));
+//! pam_module!(PamTime);
 //! ```
 
 extern crate libc;

--- a/test-module/src/lib.rs
+++ b/test-module/src/lib.rs
@@ -7,17 +7,17 @@ use pamsm::{PamServiceModule, Pam, PamFlag, PamError};
 struct PamTime;
 
 impl PamServiceModule for PamTime {
-    fn authenticate(self: &Self, pamh: Pam, _: PamFlag, args: Vec<String>) -> PamError {
+    fn authenticate(_pamh: Pam, _: PamFlag, args: Vec<String>) -> PamError {
 
         // If you need login/password here, that works like this:
         //
-        //  let user = match pamh.get_user(None) {
+        //  let user = match _pamh.get_user(None) {
         //      Ok(Some(u)) => u,
         //      Ok(None) => return PamError::USER_UNKNOWN,
         //      Err(e) => return e,
         //  };
-		//
-        //  let pass = match pamh.get_authtok(None) {
+        //
+        //  let pass = match _pamh.get_authtok(None) {
         //      Ok(Some(p)) => p,
         //      Ok(None) => return PamError::AUTH_ERR,
         //      Err(e) => return e,
@@ -33,5 +33,4 @@ impl PamServiceModule for PamTime {
     }
 }
 
-pamsm_init!(Box::new(PamTime));
-
+pam_module!(PamTime);


### PR DESCRIPTION
This changes `PamServiceModule` to use static methods and introduces
a new macro `pam_module`, which only exports static PAM entrypoints.
This is to avoid potentially racing/incorrect behavior on multi-thread
modules.